### PR TITLE
Update sync so that if there is an add and a delete in the same batch the post is just never added

### DIFF
--- a/src/endpoints/readFirehose/index.ts
+++ b/src/endpoints/readFirehose/index.ts
@@ -192,7 +192,10 @@ const processBatch = async (
   const deletesToApply = deletes
     .filter(({ author }) => followByFinder.getFollowedBy(author) != null)
     .map((del) => del.uri);
-  await savePostsBatch(postsToSave, deletesToApply);
+  const notDeletedPostsToSave = postsToSave.filter(
+    (post) => !deletesToApply.includes(post.uri)
+  );
+  await savePostsBatch(notDeletedPostsToSave, deletesToApply);
   return {
     postsSaved,
     repostsSaved,


### PR DESCRIPTION


This addresses a problem with duplicate key errors that could happen in this case